### PR TITLE
Add UPDuino  (iCE40UP5K) support to apple-one

### DIFF
--- a/boards/ice40up5k_yosys/Makefile
+++ b/boards/ice40up5k_yosys/Makefile
@@ -1,0 +1,80 @@
+DEVICE = 5k
+PACKAGE = sg48
+FREQ_OSC = 48
+FREQ_PLL = 25
+
+PIN_DEF=ice40up5k.pcf
+
+
+SOURCEDIR = ../../rtl
+BUILDDIR = build
+PLL=$(BUILDDIR)/pll.sv
+
+all: $(PLL) apple1 prog
+
+info:
+	@echo "       To build: make apple1"
+	@echo "     To program: make prog"
+	@echo "To build report: make report"
+	@echo "    To clean up: make clean"
+
+dir:
+	mkdir -p $(BUILDDIR)
+
+# ------ TEMPLATES ------
+$(BUILDDIR)/%.blif: $(SOURCEDIR)/%.v
+	yosys -q -p "chparam -list; hierarchy -top apple1_top; synth_ice40 -blif $@" $^
+
+$(BUILDDIR)/%.asc: $(PIN_DEF) $(BUILDDIR)/%.blif
+	arachne-pnr -d $(DEVICE) -P $(PACKAGE) -o $@ -p $^
+
+$(BUILDDIR)/%.bin: $(BUILDDIR)/%.asc
+	icepack $^ $@
+
+%.rpt: $(BUILDDIR)/%.asc
+	icetime -d $(DEVICE) -P $(PACKAGE) -c $(FREQ_PLL) -mtr $@ $<
+
+%_tb.vvp: %_tb.v %.v
+	iverilog -o $@ $^
+
+%_tb.vcd: %_tb.vvp
+	vvp -N $< +vcd=$@
+
+$(PLL):
+	icepll $(QUIET) -i $(FREQ_OSC) -o $(FREQ_PLL) -m -f $@
+# ------ APPLE 1 ------
+apple1: dir $(BUILDDIR)/apple1.bin
+report: dir apple1.rpt
+
+$(BUILDDIR)/apple1.bin: $(BUILDDIR)/apple1.asc
+$(BUILDDIR)/apple1.asc: $(BUILDDIR)/apple1.blif
+$(BUILDDIR)/apple1.blif: $(BUILDDIR)/pll.sv \
+	$(SOURCEDIR)/apple1.v \
+	$(SOURCEDIR)/clock.v \
+	$(SOURCEDIR)/pwr_reset.v \
+	$(SOURCEDIR)/ram.v \
+	$(SOURCEDIR)/rom_wozmon.v \
+	$(SOURCEDIR)/rom_basic.v \
+	$(SOURCEDIR)/cpu/arlet_6502.v \
+	$(SOURCEDIR)/cpu/arlet/ALU.v \
+	$(SOURCEDIR)/cpu/arlet/cpu.v \
+	$(SOURCEDIR)/uart/uart.v \
+	$(SOURCEDIR)/uart/async_tx_rx.v \
+	$(SOURCEDIR)/vga/vga.v \
+	$(SOURCEDIR)/vga/vram.v \
+	$(SOURCEDIR)/vga/font_rom.v \
+	$(SOURCEDIR)/ps2keyboard/debounce.v \
+	$(SOURCEDIR)/ps2keyboard/ps2keyboard.v \
+	$(SOURCEDIR)/boards/ice40up5k/apple1_up5k.v
+
+apple1.rpt: $(BUILDDIR)/apple1.asc
+
+prog: dir $(BUILDDIR)/apple1.bin
+	iceprog -S $(filter-out $<,$^)
+
+# ------ HELPERS ------
+clean:
+	rm -rf build apple1.rpt
+
+.SECONDARY:
+.PHONY: all info clean prog iceprog

--- a/boards/ice40up5k_yosys/README.md
+++ b/boards/ice40up5k_yosys/README.md
@@ -1,0 +1,31 @@
+ # iCE40UP5K support 
+
+This board directory builds for the iCE40UP5K in the QFN48 (SG48) package.  iCE40UP5K SG48 is the part used on the [Gnarly Grey UPDuino Mini board](https://gnarlygrey.atspace.cc/development-platform.html). 
+ 
+ ## Peripheral support
+
+So far only UART is tested and supported.  Three bits of the PC monitor bus are mapped to the dedicated LED drivers to give some indication of the currently running code.
+
+VGA is brought out to pins but have not been tested.
+
+PS/2, button, and TM1638 front panel are not supported.
+
+At this time, all ROM and RAM are mapped as block RAM, and arachne-pnr reports that 28/30 BRAMs are utilized.  If larger ROMs or more RAM is needed, RAM should be moved to SPRAM instead.
+
+The on-chip oscillator and PLL are used to generate the 25MHz clock used by the design.
+
+See the .pcf for pin connections.  Note that the iCE40UP5K pin numbers in the .pcf correspond to the UPDuino pin silkscreen labels.
+
+ ## Building
+
+Install a recent IceStorm toolchain, and:
+
+make clean all
+
+ ## Use
+
+Flash using your method of choice.  Attach a 3.3V serial connection to uart_tx (output to PC) and uart_rx (input from PC).  Start a terminal at 115200,n,8,1.
+
+Toggling CRESET_B restarts to the Woz monitor.
+
+The Woz monitor is a simple hex debugger.  To run BASIC, type: "E000R".  Note that both BASIC and the monitor require commands to be input as caps.

--- a/boards/ice40up5k_yosys/ice40up5k.pcf
+++ b/boards/ice40up5k_yosys/ice40up5k.pcf
@@ -1,0 +1,19 @@
+# For the iCE40UP-5K UPDuino board
+
+### UART (FTDI Channel B)
+set_io uart_rx   12
+set_io uart_tx   21
+set_io uart_cts  13
+
+### Breakout Board LEDs
+set_io red_led   41
+set_io green_led 40
+set_io blue_led  39
+
+### VGA Display
+set_io vga_h_sync 18
+set_io vga_v_sync 11
+set_io vga_red 10
+set_io vga_grn 9
+set_io vga_blu 6
+

--- a/rtl/boards/ice40up5k/apple1_up5k.v
+++ b/rtl/boards/ice40up5k/apple1_up5k.v
@@ -1,0 +1,82 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+// Description: Apple 1 implementation for the iCE40HX8K dev
+//              board.
+//
+// Author.....: Alan Garfield
+// Date.......: 26-1-2018
+//
+
+module apple1_top(
+    // I/O interface to computer
+    input  uart_rx,         // asynchronous serial data input from computer
+    output uart_tx,         // asynchronous serial data output to computer
+    output uart_cts,        // clear to send flag to computer
+
+    // Outputs to VGA display
+    output vga_h_sync,          // hozizontal VGA sync pulse
+    output vga_v_sync,          // vertical VGA sync pulse
+    output reg vga_red,         // red VGA signal
+    output reg vga_grn,         // green VGA signal
+    output reg vga_blu,         // blue VGA signal
+
+    // Tricolor LED on the UPDuino
+    output red_led,
+    output green_led,
+    output blue_led
+);
+
+    wire [15:0] leds;
+    assign red_led    = ~leds[9];
+    assign green_led  = ~leds[8];
+    assign blue_led   = ~leds[7];
+
+    wire clk25;
+    wire clk;
+
+	wire clk25;
+	SB_HFOSC inthosc (
+		.CLKHFPU(1'b1),
+		.CLKHFEN(1'b1),
+		.CLKHF(clk)
+	);
+
+   pll pll(
+	   .clock_in(clk),
+	   .clock_out(clk25),
+   ); 
+
+
+    // apple one main system
+    apple1 my_apple1(
+        .clk25(clk25),
+        .rst_n(1'b1),
+        .uart_rx(uart_rx),
+        .uart_tx(uart_tx),
+        .uart_cts(uart_cts),
+        .clr_screen_btn(1'b0),
+        .vga_h_sync(vga_h_sync),
+        .vga_v_sync(vga_v_sync),
+        .vga_red(vga_red),
+        .vga_grn(vga_grn),
+        .vga_blu(vga_blu),
+        .pc_monitor(leds),
+	.ps2_select(1'b0), // no ps2 keyboard right now
+    );
+    
+endmodule


### PR DESCRIPTION
I was able to get this project working with the UPDuino Mini running the iCE40UP5K.  Due to pin and onboard peripheral limitations I've only tested out the UART, but I don't see why VGA, PS/2, and the SPI panel features wouldn't work as well.