### PR TITLE
Support for Olimex iCE40HX8K-EVB fpga board

### DIFF
--- a/boards/olimex_ice40hx8k_evb_yosys/Makefile
+++ b/boards/olimex_ice40hx8k_evb_yosys/Makefile
@@ -1,0 +1,72 @@
+DEVICE = hx8k
+PIN_DEF=ice40hx8k.pcf
+
+SOURCEDIR = ../../rtl
+BUILDDIR = build
+
+all: apple1 prog
+
+info:
+	@echo "       To build: make apple1"
+	@echo "     To program: make prog"
+	@echo "To build report: make report"
+	@echo "    To clean up: make clean"
+
+dir:
+	mkdir -p $(BUILDDIR)
+
+# ------ TEMPLATES ------
+$(BUILDDIR)/%.blif: $(SOURCEDIR)/%.v
+	yosys -q  -p "chparam -list; hierarchy -top apple1_top; synth_ice40 -blif $@" $^
+
+$(BUILDDIR)/%.asc: $(PIN_DEF) $(BUILDDIR)/%.blif
+	arachne-pnr -d $(subst hx,,$(subst lp,,$(DEVICE))) -o $@ -p $^
+
+$(BUILDDIR)/%.bin: $(BUILDDIR)/%.asc
+	icepack $^ $@
+
+%.rpt: $(BUILDDIR)/%.asc
+	icetime -d $(DEVICE) -mtr $@ $<
+
+%_tb.vvp: %_tb.v %.v
+	iverilog -o $@ $^
+
+%_tb.vcd: %_tb.vvp
+	vvp -N $< +vcd=$@
+
+# ------ APPLE 1 ------
+apple1: dir $(BUILDDIR)/apple1.bin
+report: dir apple1.rpt
+
+$(BUILDDIR)/apple1.bin: $(BUILDDIR)/apple1.asc
+$(BUILDDIR)/apple1.asc: $(BUILDDIR)/apple1.blif
+$(BUILDDIR)/apple1.blif: $(SOURCEDIR)/apple1.v \
+	$(SOURCEDIR)/clock.v \
+	$(SOURCEDIR)/pwr_reset.v \
+	$(SOURCEDIR)/ram.v \
+	$(SOURCEDIR)/rom_wozmon.v \
+	$(SOURCEDIR)/rom_basic.v \
+	$(SOURCEDIR)/cpu/arlet_6502.v \
+	$(SOURCEDIR)/cpu/arlet/ALU.v \
+	$(SOURCEDIR)/cpu/arlet/cpu.v \
+	$(SOURCEDIR)/uart/uart.v \
+	$(SOURCEDIR)/uart/async_tx_rx.v \
+	$(SOURCEDIR)/vga/vga.v \
+	$(SOURCEDIR)/vga/vram.v \
+	$(SOURCEDIR)/vga/font_rom.v \
+	$(SOURCEDIR)/ps2keyboard/debounce.v \
+	$(SOURCEDIR)/ps2keyboard/ps2keyboard.v \
+	$(SOURCEDIR)/boards/olimex_ice40hx8k/pll.v \
+	$(SOURCEDIR)/boards/olimex_ice40hx8k/apple1_hx8k.v
+
+apple1.rpt: $(BUILDDIR)/apple1.asc
+
+prog: dir $(BUILDDIR)/apple1.bin
+	iceprogduino  $(filter-out $<,$^)
+
+# ------ HELPERS ------
+clean:
+	rm -rf build apple1.rpt
+
+.SECONDARY:
+.PHONY: all info clean prog iceprog

--- a/boards/olimex_ice40hx8k_evb_yosys/README.md
+++ b/boards/olimex_ice40hx8k_evb_yosys/README.md
@@ -1,0 +1,28 @@
+# Olimex iCE40hx8k-evb support
+
+This adds support for building apple one design for [Olimex iCE40hx8k-evb board](https://www.olimex.com/Products/FPGA/iCE40/iCE40HX8K-EVB/open-source-hardware)  with attached [Olimex iCE40-IO extension](https://www.olimex.com/Products/FPGA/iCE40/iCE40-IO/open-source-hardware) for vga and ps2
+
+## Peripheral support
+
+VGA port is working trought the iCE40-IO expansion.
+
+A usb-serial converter can be attached on pins 5(RX), 7(TX), 9(CTS) on either the iCE40-IO extension or witout it directly to the header of the FPGA board (pin out is the same). Consult the schematics for [iCE40-IO](https://github.com/OLIMEX/iCE40-IO/raw/master/ICE40-IO_Rev_A.pdf) and [iCE40HX8K-EVB](https://github.com/OLIMEX/iCE40HX8K-EVB/blob/master/HARDWARE/REV-B/iCE40HX8K-EVB_Rev_B.pdf) for extension header pinmap.
+
+The iCE40-IO board has a ps2 connector you can use if you have a ps2 keyboard but it's not edded to the design pin map.
+
+This port is using 1 PLL for generating the target 25Mhz clock.
+
+## Building
+Install a recent IceStorm toolchain, and:
+
+make
+
+## Use
+
+There are 2 possible ways for flashing the board:
+
+1. [Olimex OLIMEXINO-32U4 as programmer](https://www.olimex.com/wiki/ICE40HX1K-EVB#Preparing_OLIMEXINO-32U4_as_programmer) 
+
+2. [Iceprog with Raspberry PI](https://www.olimex.com/wiki/ICE40HX1K-EVB#Iceprog_with_Raspberry_PI)
+
+To load BASIC type "E000R" with CAPS LOCK on.

--- a/boards/olimex_ice40hx8k_evb_yosys/ice40hx8k.pcf
+++ b/boards/olimex_ice40hx8k_evb_yosys/ice40hx8k.pcf
@@ -1,0 +1,28 @@
+# For the olimex-iCE40HX8K-EVB
+# plus iCE40-IO expansion board with vga and ps2
+
+## System Clock 100Mhz
+set_io clk J3
+
+### UART
+set_io uart_rx E4
+set_io uart_tx B2
+set_io uart_cts F5
+
+
+set_io button[0] K11
+set_io button[1] P13
+
+### VGA Display
+set_io vga_v_sync H2
+set_io vga_h_sync J4
+
+set_io vga_r[0] E3
+set_io vga_r[1] H5
+set_io vga_r[2] F3
+set_io vga_g[0] H3
+set_io vga_g[1] F2
+set_io vga_g[2] H6
+set_io vga_b[0] F1
+set_io vga_b[1] H4
+set_io vga_b[2] G2

--- a/rtl/boards/olimex_ice40hx8k/apple1_hx8k.v
+++ b/rtl/boards/olimex_ice40hx8k/apple1_hx8k.v
@@ -1,0 +1,69 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+// Description: Apple 1 implementation for the iCE40HX8K dev
+//              board.
+//
+// Author.....: Alan Garfield
+// Date.......: 26-1-2018
+//
+
+module apple1_top(
+    input  clk,             // 100 MHz board clock
+
+    // I/O interface to computer
+    input  uart_rx,         // asynchronous serial data input from computer
+    output uart_tx,         // asynchronous serial data output to computer
+    output uart_cts,        // clear to send flag to computer
+
+    // Outputs to VGA display
+    output vga_h_sync,          // hozizontal VGA sync pulse
+    output vga_v_sync,          // vertical VGA sync pulse
+    output [2:0] vga_r,         // red VGA signal
+    output [2:0] vga_g,         // green VGA signal
+    output [2:0] vga_b,         // blue VGA signal
+
+    input [1:0] button
+);
+
+    wire clk25;
+
+    pll pll(.clock_in(clk),
+        .clock_out(clk25),
+    );
+
+    wire vga_bit;
+
+    // set the monochrome base colour here..
+    assign vga_r[2:0] = vga_bit ? 3'b100 : 3'b000;
+    assign vga_g[2:0] = vga_bit ? 3'b111 : 3'b000;
+    assign vga_b[2:0] = vga_bit ? 3'b100 : 3'b000;
+
+    // apple one main system
+    apple1 my_apple1(
+        .clk25(clk25),
+        .rst_n(button[0]),
+        .uart_rx(uart_rx),
+        .uart_tx(uart_tx),
+        .uart_cts(uart_cts),
+        .clr_screen_btn(0),
+        .vga_h_sync(vga_h_sync),
+        .vga_v_sync(vga_v_sync),
+        .vga_red(vga_bit),
+        .ps2_select(1'b0),
+    );
+endmodule

--- a/rtl/boards/olimex_ice40hx8k/pll.v
+++ b/rtl/boards/olimex_ice40hx8k/pll.v
@@ -1,0 +1,33 @@
+/**
+ * PLL configuration
+ *
+ * This Verilog module was generated automatically
+ * using the icepll tool from the IceStorm project.
+ * Use at your own risk.
+ *
+ * Given input frequency:       100.000 MHz
+ * Requested output frequency:   25.000 MHz
+ * Achieved output frequency:    25.000 MHz
+ */
+
+module pll(
+	input  clock_in,
+	output clock_out,
+	output locked
+	);
+
+SB_PLL40_CORE #(
+		.FEEDBACK_PATH("SIMPLE"),
+		.DIVR(4'b0000),		// DIVR =  0
+		.DIVF(7'b0000111),	// DIVF =  7
+		.DIVQ(3'b101),		// DIVQ =  5
+		.FILTER_RANGE(3'b101)	// FILTER_RANGE = 5
+	) uut (
+		.LOCK(locked),
+		.RESETB(1'b1),
+		.BYPASS(1'b0),
+		.REFERENCECLK(clock_in),
+		.PLLOUTCORE(clock_out)
+		);
+
+endmodule


### PR DESCRIPTION
This adds support for Olimex iCE40HX8K-EVB with iCE40-IO extension which provides VGA and PS2 connectors. 

PS2 is not connected to the design but it can easily added. If I found a PS2 keyboard to test with I'll add the support. 