### PR TITLE
Expose ROM/RAM files as top-level parameters

### DIFF
--- a/rtl/apple1.v
+++ b/rtl/apple1.v
@@ -22,7 +22,13 @@
 // Date.......: 26-1-2018
 //
 
-module apple1(
+module apple1 #(
+    parameter BASIC_FILENAME      = "",
+    parameter FONT_ROM_FILENAME   = "",
+    parameter RAM_FILENAME        = "",
+    parameter VRAM_FILENAME       = "",
+    parameter WOZMON_ROM_FILENAME = ""
+) (
     input  clk25,               // 25 MHz master clock
     input  rst_n,               // active low synchronous reset (needed for simulation)
 
@@ -119,7 +125,9 @@ module apple1(
 
     // RAM
     wire [7:0] ram_dout;
-    ram my_ram(
+    ram #(
+        .RAM_FILENAME (RAM_FILENAME)
+    ) my_ram(
         .clk(clk25),
         .address(ab[12:0]),
         .w_en(we & ram_cs),
@@ -129,7 +137,9 @@ module apple1(
 
     // WozMon ROM
     wire [7:0] rom_dout;
-    rom_wozmon my_rom_wozmon(
+    rom_wozmon #(
+        .ROM_FILENAME (WOZMON_ROM_FILENAME)
+    ) my_rom_wozmon(
         .clk(clk25),
         .address(ab[7:0]),
         .dout(rom_dout)
@@ -137,7 +147,9 @@ module apple1(
 
     // Basic ROM
     wire [7:0] basic_dout;
-    rom_basic my_rom_basic(
+    rom_basic #(
+        .BASIC_FILENAME (BASIC_FILENAME)
+    ) my_rom_basic(
         .clk(clk25),
         .address(ab[11:0]),
         .dout(basic_dout)
@@ -185,7 +197,10 @@ module apple1(
 
     // VGA Display interface
     reg [1:0] vga_mode;
-    vga my_vga(
+    vga #(
+        .RAM_FILENAME (VRAM_FILENAME),
+        .ROM_FILENAME (FONT_ROM_FILENAME)
+    ) my_vga(
         .clk25(clk25),
         .enable(vga_cs & cpu_clken),
         .rst(rst),

--- a/rtl/boards/ice40hx8k-b-evn/apple1_hx8k.v
+++ b/rtl/boards/ice40hx8k-b-evn/apple1_hx8k.v
@@ -22,7 +22,13 @@
 // Date.......: 26-1-2018
 //
 
-module apple1_top(
+module apple1_top #(
+    parameter BASIC_FILENAME      = "../../../roms/basic.hex",
+    parameter FONT_ROM_FILENAME   = "../../../roms/vga_font_bitreversed.hex",
+    parameter RAM_FILENAME        = "../../../roms/ram.hex",
+    parameter VRAM_FILENAME       = "../../../roms/vga_vram.bin",
+    parameter WOZMON_ROM_FILENAME = "../../../roms/wozmon.hex"
+) (
     input  clk,             // 12 MHz board clock
 
     // I/O interface to computer
@@ -79,7 +85,13 @@ module apple1_top(
     );
 
     // apple one main system
-    apple1 my_apple1(
+    apple1 #(
+        .BASIC_FILENAME (BASIC_FILENAME),
+        .FONT_ROM_FILENAME (FONT_ROM_FILENAME),
+        .RAM_FILENAME (RAM_FILENAME),
+        .VRAM_FILENAME (VRAM_FILENAME),
+        .WOZMON_ROM_FILENAME (WOZMON_ROM_FILENAME)
+    ) my_apple1(
         .clk25(clk25),
         .rst_n(button[0]),
         .uart_rx(uart_rx),

--- a/rtl/boards/terasic_de0/apple1_de0_top.v
+++ b/rtl/boards/terasic_de0/apple1_de0_top.v
@@ -22,7 +22,13 @@
 // 
 
 
-module apple1_de0_top(
+module apple1_de0_top #(
+    parameter BASIC_FILENAME      = "../../../roms/basic.hex",
+    parameter FONT_ROM_FILENAME   = "../../../roms/vga_font_bitreversed.hex",
+    parameter RAM_FILENAME        = "../../../roms/ram.hex",
+    parameter VRAM_FILENAME       = "../../../roms/vga_vram.bin",
+    parameter WOZMON_ROM_FILENAME = "../../../roms/wozmon.hex"
+) (
     input   CLOCK_50,       // the 50 MHz DE0 master clock
 
     // UART I/O signals
@@ -62,7 +68,13 @@ module apple1_de0_top(
     
     //////////////////////////////////////////////////////////////////////////    
     // Core of system
-    apple1 apple1_top(
+    apple1 #(
+        .BASIC_FILENAME (BASIC_FILENAME),
+        .FONT_ROM_FILENAME (FONT_ROM_FILENAME),
+        .RAM_FILENAME (RAM_FILENAME),
+        .VRAM_FILENAME (VRAM_FILENAME),
+        .WOZMON_ROM_FILENAME (WOZMON_ROM_FILENAME)
+    ) apple1_top(
         .clk25(clk25),
         .rst_n(BUTTON[0]),       // we don't have any reset pulse..
         .uart_rx(UART_RXD),

--- a/rtl/boards/tinyfpga_b2/apple1_hx8k.v
+++ b/rtl/boards/tinyfpga_b2/apple1_hx8k.v
@@ -22,7 +22,13 @@
 // Date.......: 11-2-2018
 //
 
-module apple1_top(
+module apple1_top #(
+    parameter BASIC_FILENAME      = "../../../roms/basic.hex",
+    parameter FONT_ROM_FILENAME   = "../../../roms/vga_font_bitreversed.hex",
+    parameter RAM_FILENAME        = "../../../roms/ram.hex",
+    parameter VRAM_FILENAME       = "../../../roms/vga_vram.bin",
+    parameter WOZMON_ROM_FILENAME = "../../../roms/wozmon.hex"
+) (
     input  pin3_clk_16mhz,// 16 MHz board clock
 
     // Outputs to VGA display
@@ -64,7 +70,13 @@ module apple1_top(
     wire vga_blu;
 
     // apple one main system
-    apple1 my_apple1(
+    apple1 #(
+        .BASIC_FILENAME (BASIC_FILENAME),
+        .FONT_ROM_FILENAME (FONT_ROM_FILENAME),
+        .RAM_FILENAME (RAM_FILENAME),
+        .VRAM_FILENAME (VRAM_FILENAME),
+        .WOZMON_ROM_FILENAME (WOZMON_ROM_FILENAME)
+    ) my_apple1(
         .clk25(clk25),
         .rst_n(button[0]),
         .ps2_clk(pin7), // PS/2 not working with my keyboard

--- a/rtl/boards/upduino/apple1_up5k.v
+++ b/rtl/boards/upduino/apple1_up5k.v
@@ -22,7 +22,13 @@
 // Date.......: 26-1-2018
 //
 
-module apple1_top(
+module apple1_top #(
+    parameter BASIC_FILENAME      = "../../../roms/basic.hex",
+    parameter FONT_ROM_FILENAME   = "../../../roms/vga_font_bitreversed.hex",
+    parameter RAM_FILENAME        = "../../../roms/ram.hex",
+    parameter VRAM_FILENAME       = "../../../roms/vga_vram.bin",
+    parameter WOZMON_ROM_FILENAME = "../../../roms/wozmon.hex"
+) (
     // I/O interface to computer
     input  uart_rx,         // asynchronous serial data input from computer
     output uart_tx,         // asynchronous serial data output to computer
@@ -61,7 +67,13 @@ module apple1_top(
     );
 
     // apple one main system
-    apple1 my_apple1(
+    apple1 #(
+        .BASIC_FILENAME (BASIC_FILENAME),
+        .FONT_ROM_FILENAME (FONT_ROM_FILENAME),
+        .RAM_FILENAME (RAM_FILENAME),
+        .VRAM_FILENAME (VRAM_FILENAME),
+        .WOZMON_ROM_FILENAME (WOZMON_ROM_FILENAME)
+    my_apple1(
         .clk25(clk25),
         .rst_n(1'b1),
         .uart_rx(uart_rx),

--- a/rtl/ram.v
+++ b/rtl/ram.v
@@ -30,11 +30,7 @@ module ram(
     output reg [7:0] dout   // 8-bit data bus (output)
     );
 
-    `ifdef SIM
-    parameter RAM_FILENAME = "../roms/ram.hex";
-    `else
-    parameter RAM_FILENAME = "../../../roms/ram.hex";
-    `endif
+    parameter RAM_FILENAME = "";
 
     reg [7:0] ram_data[0:8191];
 

--- a/rtl/rom_basic.v
+++ b/rtl/rom_basic.v
@@ -28,11 +28,7 @@ module rom_basic(
     output reg [7:0] dout   // 8-bit data bus (output)
     );
 
-    `ifdef SIM
-    parameter BASIC_FILENAME = "../roms/basic.hex";
-    `else
-    parameter BASIC_FILENAME = "../../../roms/basic.hex";
-    `endif
+    parameter BASIC_FILENAME = "";
 
     reg [7:0] rom_data[0:4095];
 

--- a/rtl/rom_wozmon.v
+++ b/rtl/rom_wozmon.v
@@ -28,11 +28,7 @@ module rom_wozmon(
     output reg [7:0] dout   // 8-bit data bus (output)
     );
 
-    `ifdef SIM
-    parameter ROM_FILENAME = "../roms/wozmon.hex";
-    `else
-    parameter ROM_FILENAME = "../../../roms/wozmon.hex";
-    `endif
+    parameter ROM_FILENAME = "";
 
     reg [7:0] rom_data[0:255];
 

--- a/rtl/vga/font_rom.v
+++ b/rtl/vga/font_rom.v
@@ -33,11 +33,7 @@ module font_rom(
     output reg out          // single pixel from address and pixel pos
     );
 
-    `ifdef SIM
-    parameter ROM_FILENAME = "../roms/vga_font_bitreversed.hex";
-    `else
-    parameter ROM_FILENAME = "../../../roms/vga_font_bitreversed.hex";
-    `endif
+    parameter ROM_FILENAME = "";
 
     reg [7:0] rom[0:1023];
 

--- a/rtl/vga/vga.v
+++ b/rtl/vga/vga.v
@@ -26,6 +26,9 @@ module vga(
     parameter vbp = 31;         // end of vertical back porch
     parameter vfp = 511;        // beginning of vertical front porch
 
+    // Video RAM contents
+    parameter RAM_FILENAME = "";
+
     // registers for storing the horizontal & vertical counters
     reg [9:0] h_cnt;
     reg [9:0] v_cnt;
@@ -56,6 +59,9 @@ module vga(
     wire [3:0] font_pixel;
     wire [4:0] font_line;
     wire font_out;
+
+    // Font ROM contents
+    parameter ROM_FILENAME = "";
 
     // cpu control registers
     reg char_seen;
@@ -116,7 +122,9 @@ module vga(
     //////////////////////////////////////////////////////////////////////////
     // Character ROM
 
-    font_rom my_font_rom(
+    font_rom #(
+        .ROM_FILENAME (ROM_FILENAME)
+    ) my_font_rom(
         .clk(clk25),
         .mode(mode),
         .character(font_char),
@@ -128,7 +136,9 @@ module vga(
     //////////////////////////////////////////////////////////////////////////
     // Video RAM
 
-    vram my_vram(
+    vram #(
+        .RAM_FILENAME (RAM_FILENAME)
+    ) my_vram(
         .clk(clk25),
         .read_addr(vram_r_addr),
         .write_addr(vram_w_addr),

--- a/rtl/vga/vram.v
+++ b/rtl/vga/vram.v
@@ -32,11 +32,7 @@ module vram(
     output reg [5:0] dout       // 6-bit data bus (output)
     );
 
-    `ifdef SIM
-    parameter RAM_FILENAME = "../roms/vga_vram.bin";
-    `else
-    parameter RAM_FILENAME = "../../../roms/vga_vram.bin";
-    `endif
+    parameter RAM_FILENAME = "";
 
     reg [5:0] ram_data[0:2047];
 

--- a/tools/iverilog/apple1_tb.v
+++ b/tools/iverilog/apple1_tb.v
@@ -23,7 +23,13 @@
 
 `timescale 1ns/1ps
 
-module apple1_tb;
+module apple1_tb #(
+    parameter BASIC_FILENAME      = "../roms/basic.hex",
+    parameter FONT_ROM_FILENAME   = "../roms/vga_font_bitreversed.hex",
+    parameter RAM_FILENAME        = "../roms/ram.hex",
+    parameter VRAM_FILENAME       = "../roms/vga_vram.bin",
+    parameter WOZMON_ROM_FILENAME = "../roms/wozmon.hex"
+);
 
     reg clk25, uart_rx, rst_n;
     wire uart_tx, uart_cts;
@@ -69,9 +75,11 @@ module apple1_tb;
     //////////////////////////////////////////////////////////////////////////
     // Core of system
     apple1 #(
-        "../roms/ram.hex",
-        "../roms/wozmon.hex",
-        "../roms/basic.hex"
+        .BASIC_FILENAME (BASIC_FILENAME),
+        .FONT_ROM_FILENAME (FONT_ROM_FILENAME),
+        .RAM_FILENAME (RAM_FILENAME),
+        .VRAM_FILENAME (VRAM_FILENAME),
+        .WOZMON_ROM_FILENAME (WOZMON_ROM_FILENAME)
     ) core_top (
         .clk25(clk25),
         .rst_n(rst_n),


### PR DESCRIPTION
This allows file names to be overridden at compile-time.

It also gets rid of the ifdef SIM in the verilog components