### PR TITLE
Fixes for upduino rtl

### DIFF
--- a/rtl/boards/upduino/apple1_up5k.v
+++ b/rtl/boards/upduino/apple1_up5k.v
@@ -73,7 +73,7 @@ module apple1_top #(
         .RAM_FILENAME (RAM_FILENAME),
         .VRAM_FILENAME (VRAM_FILENAME),
         .WOZMON_ROM_FILENAME (WOZMON_ROM_FILENAME)
-    my_apple1(
+    ) my_apple1(
         .clk25(clk25),
         .rst_n(1'b1),
         .uart_rx(uart_rx),

--- a/rtl/boards/upduino/apple1_up5k.v
+++ b/rtl/boards/upduino/apple1_up5k.v
@@ -79,7 +79,6 @@ module apple1_top #(
         .uart_rx(uart_rx),
         .uart_tx(uart_tx),
         .uart_cts(uart_cts),
-        .clr_screen_btn(1'b0),
         .vga_h_sync(vga_h_sync),
         .vga_v_sync(vga_v_sync),
         .vga_red(vga_red),


### PR DESCRIPTION
The upduino rtl contained a syntax error and invalid port.  This patch corrects those two issues, and the upduino board appears to be happy again. 

(Awesome project btw!)